### PR TITLE
CDATA blocks with ] or [ characters inside

### DIFF
--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -39,7 +39,7 @@ function text(data) {
     if (!data.length) {
         return;
     }
-    currentObject['$t'] = data;
+    currentObject['$t'] = (currentObject['$t'] || "") + data;
 }
 
 function endElement(name) {


### PR DESCRIPTION
If a CDATA block includes ] or [ characters then the textual data for the element is passed several times in separate blocks. Currently only the last of these blocks is used.

For example

```
<![CDATA[ test1 test2 ] test3 ]]>
```

Will be added as the text node as

```
$t: "] test3 "
```

When actually it should be 

```
$t: " test1 test2 ] test3 "
```
