### PR TITLE
Remove console.log on xml parse error

### DIFF
--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -79,7 +79,6 @@ module.exports = function(xml, _options) {
     }
 
     if (!parser.parse(xml)) {
-        console.log('-->' + xml + '<--');
         throw new Error('There are errors in your xml file: ' + parser.getError());
     }
 


### PR DESCRIPTION
For high-traffic servers, this becomes an issue when logs are written to disc. This is a better alternative:

``` javascript
try {
   var json = xml2json(source);
} catch(e) {
   console.log('Unable to parse XML from %s, source: \n%s', url, source);
}
```
