### PR TITLE
add `attributes` and `textNodeName` options to xml parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ console.log(json);
 * if you want to get the Javascript object then you might want to invoke parser.toJson(xml, {object: true});
 * if you want a reversible json to xml then you should use parser.toJson(xml, {reversible: true});
 * if you want to override the default "$t" key name for a node's text value, specify the textNodeKey option. e.g., `parser.toJson(xml, {textNodeKey: "text"})`
+* if you want to prevent xml node attributes from appearing in the json, specify attributes: false. e.g., `parser.toJson(xml, {attributes: false})`. The default behavior is attributes: true.
 
 ## License
 Copyright 2011 BugLabs Inc. All rights reserved.

--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -7,6 +7,9 @@ var ancestors = [];
 
 var options = {}; //configuration options
 function startElement(name, attrs) {
+    // if options.attributes is false, throw away attributes
+    if (!options.attributes) attrs = {};
+
     if (! (name in currentObject)) {
         currentObject[name] = attrs;
     } else if (! (currentObject[name] instanceof Array)) {
@@ -72,7 +75,8 @@ module.exports = function(xml, _options) {
     options = {
         object: false,
         reversible: false,
-        textNodeKey: '$t'
+        textNodeKey: '$t',
+        attributes: true
     };
 
     for (var opt in _options) {

--- a/test/test.js
+++ b/test/test.js
@@ -48,9 +48,9 @@ fs.readdir(fixturesPath, function(err, files) {
 });
 
 // test options.textNodeKey custom value
-var xml = '<ref href="http://example.com">http://example.com</ref>';
+var xml = '<a href="http://example.com">Example Site</a>';
 var actual = parser.toJson(xml, {object: true, textNodeKey: 'hi'});
-var json = '{"ref":{"href":"http://example.com","hi":"http://example.com"}}';
+var json = '{"a":{"href":"http://example.com","hi":"Example Site"}}';
 assert.deepEqual(actual, JSON.parse(json));
 
 // test options.textNodeKey default value
@@ -59,3 +59,9 @@ var json = json.replace('"hi":', '"$t":');
 assert.deepEqual(actual, JSON.parse(json));
 
 console.log('[xml2json options.textNodeKey] passed');
+
+// test options.attributes = false
+var actual = parser.toJson(xml, {object: true, attributes: false});
+var json = '{"a": "Example Site"}'
+assert.deepEqual(actual, JSON.parse(json));
+console.log('[xml2json options.attributes] passed');


### PR DESCRIPTION
I added a couple options (and tests) for xml2json.js that I needed and that others may find useful:
- a `textNodeKey` option to override the default `$t` -- because I need to generate JSON that I can feed into mongodb. mongodb does not like '$' in JSON key names. When not specified, the `textNodeKey` option defaults to '$t'
- an `attributes` option to specify whether or not the xml's nodes' attributes are converted to the JSON. The default is `attributes: true` which preserves the usual behavior of allowing attributes into the generated JSON.
