### PR TITLE
Change node-expat dependency to allow for anything below 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "main": "index", 
     "contributors":[ {"name": "Camilo Aguilar", "email": "camilo@buglabs.net"}],
     "dependencies": {
-       "node-expat": "1.4.1"
+       "node-expat": ">=1.4.1 <2.0.0"
     }
 }
 


### PR DESCRIPTION
This is just a simple change to allow xml2json to work with newer-ish versions of node-expat, since v1.4.1 (the current requirement) doesn't install properly on the latest NodeJS.

This doesn't seem to have any issues and all the tests pass. It should fix #22, #25, and #26.
