### PR TITLE
toXml() fails on a specific XML structure

### DIFF
--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -20,14 +20,20 @@ module.exports = function toXml(json, xml) {
 
     // First pass, extract strings only
     for (var i = 0; i < len; i++) {
-        var key = keys[i];
-        if (typeof(obj[key]) == 'string') {
-            if (key == '$t') {
-                xml += obj[key];
-            } else {
-                xml = xml.replace(/>$/, '');
-                xml += ' ' + key + '="' + obj[key] + '">';
-            }
+        var key = keys[i], value = obj[key], isArray = Array.isArray(value);
+        if (typeof(obj[key]) == 'string' || isArray) {
+			var it = isArray ? value : [value];
+
+			it.forEach(function(subVal) {
+				if (typeof(subVal) != 'object') {
+					if (key == '$t') {
+						xml += subVal;
+					} else {
+						xml = xml.replace(/>$/, '');
+						xml += ' ' + key + '="' + subVal + '">';
+					}
+				}
+			})
         }
     }
 
@@ -39,9 +45,13 @@ module.exports = function toXml(json, xml) {
             var elems = obj[key];
             var l = elems.length;
             for (var j = 0; j < l; j++) {
-                xml += '<' + key + '>';
-                xml = toXml(elems[j], xml);
-                xml += '</' + key + '>';
+				var elem = elems[j];
+
+				if (typeof(elem) == 'object') {
+					xml += '<' + key + '>';
+					xml = toXml(elem, xml);
+					xml += '</' + key + '>';
+				}
             }
         } else if (typeof(obj[key]) == 'object') {
             xml += '<' + key + '>';


### PR DESCRIPTION
When XML looks like
`<blah attr="1"><attr value="2"></attr></blah>`
then it parses to something like
`{blah: {attr: [1, {value: 2}]}`
and `toXml()` fails on `Object.keys()` for `1`.
