### PR TITLE
Do not handle the strings 'yes' and 'no' as boolean

### DIFF
--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -96,11 +96,11 @@ function coerce(value) {
 
     var _value = value.toLowerCase();
 
-    if (_value == 'true' || _value == 'yes') {
+    if (_value == 'true') {
         return true;
     }
 
-    if (_value == 'false' || _value == 'no') {
+    if (_value == 'false') {
         return false;
     }
 


### PR DESCRIPTION
eg. <country>NO</country> (ISO 3166 country code for Norway) would result in “country: false”

If this pull-request can't be accepted, another idea would be to make an option for coerceStrict or likewise, to avoid this problem.
