### PR TITLE
Upgrade node-expat to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         {"name": "Camilo Aguilar", "email": "camilo.aguilar@gmail.com"}
     ],
     "dependencies": {
-       "node-expat": "2.0.0"
+       "node-expat": "2.1.4"
     },
     "bin": {
         "xml2json": "bin/xml2json"


### PR DESCRIPTION
This will allow compiling xml2json on newer versions of Node, such as v0.11.x and above.

I ran the existing tests and they all pass.

``` bash
[xml2json: array-notation.xml->array-notation.json] passed!
[xml2json: coerce.xml->coerce.json] passed!
[json2xml: domain-reversible.json->domain.xml] passed!
[xml2json: domain.xml->domain.json] passed!
[xml2json: large.xml->large.json] passed!
[xml2json: reorder.xml->reorder.json] passed!
[xml2json: spacetext.xml->spacetext.json] passed!
```
