### PR TITLE
Upgrade node-expat to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         {"name": "Camilo Aguilar", "email": "camilo.aguilar@gmail.com"}
     ],
     "dependencies": {
-       "node-expat": "2.1.4"
+       "node-expat": "^2.3.0"
     },
     "bin": {
         "xml2json": "bin/xml2json"


### PR DESCRIPTION
The version bump adds support for `node 0.11.13`. This PR also sets the version of `node-expat` to be "compatible with 2.3.0".
