### PR TITLE
add sanitize options for toXml function. (& -> &amp;, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ parser.toJson(xml, options);
 parser.toXml(json, options);
 ```
 
-### Options object
+### Options object for `toJson`
 
 Default values:
 ```javascript
@@ -67,7 +67,16 @@ var chars =  {
 };
 ```
 
+### Options object for `toXml`
 
+Default values:
+```javascript
+var options = {
+    sanitize: false
+};
+```
+
+`sanitize: false` is the default option to behave like previous versions
 
 
 (*) xml2json tranforms CDATA content to JSON, but it doesn't generate a reversible structure.

--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -1,7 +1,21 @@
-module.exports = function toXml(json, xml) {
+var san = require('./sanitize.js')
+
+module.exports = function toXml(json, xml, _options) {
     var xml = xml || '';
+    if (_options === undefined) {
+        _options = xml;
+        xml = '';
+    }
+    
     if (json instanceof Buffer) {
         json = json.toString();
+    }
+
+    options = {
+        sanitize: false
+    };
+    for (var opt in _options) {
+        options[opt] = _options[opt];
     }
 
     var obj = null;
@@ -17,7 +31,7 @@ module.exports = function toXml(json, xml) {
 
     var keys = Object.keys(obj);
     var len = keys.length;
-
+    
     // First pass, extract strings only
     for (var i = 0; i < len; i++) {
         var key = keys[i], value = obj[key], isArray = Array.isArray(value);
@@ -30,6 +44,9 @@ module.exports = function toXml(json, xml) {
 						xml += subVal;
 					} else {
 						xml = xml.replace(/>$/, '');
+                        if (options.sanitize) {
+                            subVal = san.sanitize(subVal);
+                        }
 						xml += ' ' + key + '="' + subVal + '">';
 					}
 				}
@@ -49,13 +66,13 @@ module.exports = function toXml(json, xml) {
 
 				if (typeof(elem) == 'object') {
 					xml += '<' + key + '>';
-					xml = toXml(elem, xml);
+					xml = toXml(elem, xml, options);
 					xml += '</' + key + '>';
 				}
             }
         } else if (typeof(obj[key]) == 'object') {
             xml += '<' + key + '>';
-            xml = toXml(obj[key], xml);
+            xml = toXml(obj[key], xml, options);
             xml += '</' + key + '>';
         }
     }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,0 +1,34 @@
+/**
+ * Simple sanitization. It is not intended to sanitize
+ * malicious element values.
+ *
+ * character | escaped
+ *      <       &lt;
+ *      >       &gt;
+ *      (       &#40;
+ *      )       &#41;
+ *      #       &#35;
+ *      &       &amp;
+ *      "       &quot;
+ *      '       &apos;
+ */
+var chars =  {  '<': '&lt;',
+                '>': '&gt;',
+                '(': '&#40;',
+                ')': '&#41;',
+                '#': '&#35;',
+                '&': '&amp;',
+                '"': '&quot;',
+                "'": '&apos;' };
+
+exports.sanitize = function sanitize(value) {
+    if (typeof value !== 'string') {
+        return value;
+    }
+
+    Object.keys(chars).forEach(function(key) {
+        value = value.replace(key, chars[key]);
+    });
+
+    return value;
+}

--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -1,4 +1,5 @@
 var expat = require('node-expat');
+var san = require('./sanitize.js')
 
 // This object will hold the final result.
 var obj = {};
@@ -58,7 +59,7 @@ function text(data) {
     }
 
     if (options.sanitize) {
-        data = sanitize(data);
+        data = san.sanitize(data);
     }
 
     currentObject['$t'] = coerce((currentObject['$t'] || '') + data);
@@ -107,41 +108,6 @@ function coerce(value) {
     return value;
 }
 
-
-/**
- * Simple sanitization. It is not intended to sanitize
- * malicious element values.
- *
- * character | escaped
- *      <       &lt;
- *      >       &gt;
- *      (       &#40;
- *      )       &#41;
- *      #       &#35;
- *      &       &amp;
- *      "       &quot;
- *      '       &apos;
- */
-var chars =  {  '<': '&lt;',
-                '>': '&gt;',
-                '(': '&#40;',
-                ')': '&#41;',
-                '#': '&#35;',
-                '&': '&amp;',
-                '"': '&quot;',
-                "'": '&apos;' };
-
-function sanitize(value) {
-    if (typeof value !== 'string') {
-        return value;
-    }
-
-    Object.keys(chars).forEach(function(key) {
-        value = value.replace(key, chars[key]);
-    });
-
-    return value;
-}
 
 /**
  * Parses xml to json using node-expat.

--- a/test/fixtures/xmlsanitize.xml
+++ b/test/fixtures/xmlsanitize.xml
@@ -1,0 +1,1 @@
+<e><a b="Smith &amp; Son"></a></e>

--- a/test/test-xmlsanitize.js
+++ b/test/test-xmlsanitize.js
@@ -1,0 +1,16 @@
+var fs = require('fs');
+var path = require('path');
+var parser = require('../lib');
+var assert = require('assert');
+
+var expected = fs.readFileSync(__dirname + '/fixtures/xmlsanitize.xml', {encoding: 'utf8'});
+console.log(expected)
+var json = parser.toJson(expected, {object: true, space: true});
+//console.log('xml => json: \n%j', json);
+
+var xmlres = parser.toXml(json, { sanitize: true });
+console.log(xmlres)
+//assert.deepEqual(json.doc.Column.length, 5, 'should have 5 Columns');
+assert.strictEqual(expected, xmlres, 'xml strings not equal!')
+
+console.log('xml2json toXml sanitize passed!');


### PR DESCRIPTION
I needed to put '&' into the XML file in the entity form (&amp;). The same sanitize function as in toJson function is used to achieve the result.

Second reason:
The options for toXml function were not used (resulted in [Object object] at the beginning of XML file, if you tried to use them), fixed README.