### PR TITLE
fix issue #37

### DIFF
--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -21,7 +21,8 @@ module.exports = function toXml(json, xml) {
     // First pass, extract strings only
     for (var i = 0; i < len; i++) {
         var key = keys[i], value = obj[key], isArray = Array.isArray(value);
-        if (typeof(obj[key]) == 'string' || isArray) {
+        var type = typeof(value);
+        if (type == 'string' || type == 'number' || type == 'boolean' || isArray) {
 			var it = isArray ? value : [value];
 
 			it.forEach(function(subVal) {


### PR DESCRIPTION
if coerce is true, xml2json will parse the attributes value from string
to number or boolean. So, when convert json to xml, we need test the
value type for string, number and boolean.
