### PR TITLE
Fixed issue with converting empty string or whitespace to the number 0

### DIFF
--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -90,7 +90,7 @@ function coerce(value) {
     }
 
     var num = Number(value);
-    if (!isNaN(num)) {
+    if (!isNaN(num) && /\S/.test(value)) {
         return num;
     }
 


### PR DESCRIPTION
I believe this fixes issue #54 as well; although it's unclear if @Makskuk is talking about attributes or element values.
