### PR TITLE
Add: ability to specify custom coercion methods by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ var options = {
 
 * **object:** Returns a Javascript object instead of a JSON string
 * **reversible:** Makes the JSON reversible to XML (*)
-* **coerce:** Makes type coercion. i.e.: numbers and booleans present in attributes and element values are converted from string to its correspondent data types.
+* **coerce:** Makes type coercion. i.e.: numbers and booleans present in attributes and element values are converted from string to its correspondent data types. Coerce can be optionally defined as an object with specific methods of coercion based on attribute name or tag name, with fallback to default coercion.
 * **trim:** Removes leading and trailing whitespaces as well as line terminators in element values.
 * **arrayNotation:** XML child nodes are always treated as arrays
 * **sanitize:** Sanitizes the following characters present in element values:

--- a/lib/xml2json.js
+++ b/lib/xml2json.js
@@ -13,7 +13,7 @@ function startElement(name, attrs) {
     if(options.coerce) {
         // Looping here in stead of making coerce generic as object walk is unnecessary
         for(var key in attrs) {
-            attrs[key] = coerce(attrs[key]);
+            attrs[key] = coerce(attrs[key],key);
         }
     }
 
@@ -62,7 +62,7 @@ function endElement(name) {
             currentObject['$t'] = sanitizer.sanitize(currentObject['$t']);
         }
 
-        currentObject['$t'] = coerce(currentObject['$t']);
+        currentObject['$t'] = coerce(currentObject['$t'],name);
     }
 
     if (currentElementName !== name) {
@@ -84,10 +84,13 @@ function endElement(name) {
     currentObject = ancestor;
 }
 
-function coerce(value) {
+function coerce(value,key) {
     if (!options.coerce || value.trim() === '') {
         return value;
     }
+
+    if (typeof options.coerce[key] === 'function')
+        return options.coerce[key](value);
 
     var num = Number(value);
     if (!isNaN(num)) {

--- a/test/fixtures/coerce.xml
+++ b/test/fixtures/coerce.xml
@@ -7,7 +7,7 @@
     </stringValue>
   </value>
   <value>
-    <moneyValue number='true' currencyId="USD">104.95
+    <moneyValue number='true' currencyId="USD" text="123.45">104.95
     </moneyValue>
   </value>
   <value>
@@ -26,5 +26,8 @@
   </value>
   <value>
     <stringValue>SmDZ8RlMIjDvlEW3KUibzj2Q</stringValue>
+  </value>
+  <value>
+    <text>42.42</text>
   </value>
 </itemRecord>

--- a/test/test-coerce.js
+++ b/test/test-coerce.js
@@ -13,6 +13,9 @@ assert.strictEqual(result.itemRecord.value[0].longValue['$t'], 12345);
 assert.strictEqual(result.itemRecord.value[1].stringValue.number, false);
 assert.strictEqual(result.itemRecord.value[2].moneyValue.number, true);
 assert.strictEqual(result.itemRecord.value[2].moneyValue['$t'], 104.95);
+assert.strictEqual(result.itemRecord.value[2].moneyValue.text, 123.45);
+assert.strictEqual(result.itemRecord.value[8].text['$t'], 42.42);
+
 
 // Without coercion
 result = parser.toJson(data, {reversible: true, coerce: false, object: true});
@@ -20,3 +23,14 @@ assert.strictEqual(result.itemRecord.value[0].longValue['$t'], '12345');
 assert.strictEqual(result.itemRecord.value[1].stringValue.number, 'false');
 assert.strictEqual(result.itemRecord.value[2].moneyValue.number, 'true');
 assert.strictEqual(result.itemRecord.value[2].moneyValue['$t'], '104.95');
+assert.strictEqual(result.itemRecord.value[2].moneyValue.text, '123.45');
+assert.strictEqual(result.itemRecord.value[8].text['$t'], '42.42');
+
+// With coercien as an optional object
+var result = parser.toJson(data, {reversible: true, coerce: {text:String}, object: true});
+assert.strictEqual(result.itemRecord.value[0].longValue['$t'], 12345);
+assert.strictEqual(result.itemRecord.value[1].stringValue.number, false);
+assert.strictEqual(result.itemRecord.value[2].moneyValue.number, true);
+assert.strictEqual(result.itemRecord.value[2].moneyValue['$t'], 104.95);
+assert.strictEqual(result.itemRecord.value[2].moneyValue.text, '123.45');
+assert.strictEqual(result.itemRecord.value[8].text['$t'], '42.42');


### PR DESCRIPTION
If `options.coerce` is an object, coercion is `true` but any attribute/tag first checks the coercion object for a custom function under the tag/attribute name, before falling back to the default coercion.