### PR TITLE
Sanitize text content to format a valid XML text content.

### DIFF
--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -82,6 +82,9 @@ ToXml.prototype.addAttr = function(key, val) {
 }
 ToXml.prototype.addTextContent = function(text) {
     this.completeTag();
+    if (this.options.sanitize) {
+        text = sanitizer.sanitize(text)
+    }
     this.xml += text;
 }
 ToXml.prototype.closeTag = function(key) {


### PR DESCRIPTION
In order to format a valid XML content, it needs to also sanitize the text content.