### PR TITLE
json2xml ignore null properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ var chars =  {
 Default values:
 ```javascript
 var options = {
-    sanitize: false
+    sanitize: false,
+    ignoreNull: false
 };
 ```
 
-`sanitize: false` is the default option to behave like previous versions
+* `sanitize: false` is the default option to behave like previous versions
+* **ignoreNull:** Ignores all null values
 
 
 (*) xml2json tranforms CDATA content to JSON, but it doesn't generate a reversible structure.

--- a/lib/json2xml.js
+++ b/lib/json2xml.js
@@ -21,6 +21,8 @@ module.exports = function (json, options) {
 }
 
 ToXml.prototype.parse = function(obj) {
+    if (!obj) return;
+
     var self = this;
     var keys = Object.keys(obj);
     var len = keys.length;
@@ -60,7 +62,7 @@ ToXml.prototype.parse = function(obj) {
                     self.closeTag(key);
                 }
             }
-        } else if (typeof(obj[key]) == 'object') {
+        } else if (typeof(obj[key]) == 'object' && !(self.options.ignoreNull && obj[key] === null)) {
             self.openTag(key);
             self.parse(obj[key]);
             self.closeTag(key);
@@ -97,7 +99,8 @@ ToXml.prototype.completeTag = function() {
 }
 function ToXml(options) {
     var defaultOpts = {
-        sanitize: false
+        sanitize: false,
+        ignoreNull: false
     };
 
     if (options) {

--- a/test/fixtures/null-properties-ignored.xml
+++ b/test/fixtures/null-properties-ignored.xml
@@ -1,0 +1,1 @@
+<subObject propertyNotNull="value"></subObject>

--- a/test/fixtures/null-properties-not-ignored.xml
+++ b/test/fixtures/null-properties-not-ignored.xml
@@ -1,0 +1,1 @@
+<subObject propertyNotNull="value"><propertyNull></propertyNull></subObject>

--- a/test/fixtures/null-properties.json
+++ b/test/fixtures/null-properties.json
@@ -1,0 +1,1 @@
+{"subObject": {"propertyNotNull": "value","propertyNull":null}}

--- a/test/test.js
+++ b/test/test.js
@@ -220,7 +220,7 @@ describe('xml2json', function () {
             var xml = internals.readFixture('alternate-text-node-A.xml');
             var result = parser.toJson(xml, {reversible: true});
             var json = internals.readFixture('alternate-text-node-A.json');
-            
+
             expect(result).to.equal(json);
 
             done();
@@ -231,13 +231,13 @@ describe('xml2json', function () {
             var xml = internals.readFixture('alternate-text-node-A.xml');
             var result = parser.toJson(xml, {alternateTextNode: false, reversible: true});
             var json = internals.readFixture('alternate-text-node-A.json');
-            
+
             expect(result).to.equal(json);
 
             done();
         });
 
-        
+
         it('B: uses alternate text node with option as true', function(done) {
 
             var xml = internals.readFixture('alternate-text-node-A.xml');
@@ -248,13 +248,13 @@ describe('xml2json', function () {
 
             done();
         });
-        
+
         it('C: overrides text node with option as "xx" string', function(done) {
 
             var xml = internals.readFixture('alternate-text-node-A.xml');
             var result = parser.toJson(xml, {alternateTextNode: "xx", reversible: true});
             var json = internals.readFixture('alternate-text-node-C.json');
-            
+
             expect(result).to.equal(json);
 
             done();
@@ -298,6 +298,32 @@ describe('json2xml', function () {
         expect(json).to.equal(expectedJson);
 
         done();
+    });
+
+    describe('ignore null', function () {
+
+        it('ignore null properties {ignoreNull: true}', function (done) {
+
+            var json = JSON.parse( internals.readFixture('null-properties.json') );
+            var expectedXml = internals.readFixture('null-properties-ignored.xml');
+
+            var xml = parser.toXml(json, {ignoreNull: true});
+            expect(xml).to.equal(expectedXml);
+
+            done();
+        });
+
+        it('don\'t ignore null properties (default)', function (done) {
+
+            var json = JSON.parse( internals.readFixture('null-properties.json') );
+            var expectedXml = internals.readFixture('null-properties-not-ignored.xml');
+
+            var xml = parser.toXml(json);
+            expect(xml).to.equal(expectedXml);
+
+            done();
+        });
+
     });
 });
 


### PR DESCRIPTION
Currently the method toXml throws an error if the json object contains a null property:

```
xml2json.toXml({ property: null });
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at ToXml.parse (/home/clement/dev/node-xml2json/lib/json2xml.js:25:23)
    at ToXml.parse (/home/clement/dev/node-xml2json/lib/json2xml.js:65:18)
    at Object.module.exports [as toXml] (/home/clement/dev/node-xml2json/lib/json2xml.js:19:11)
```

This PR add a new option ignoreNull, to ignore null values. By default this option is set to false, in order to avoid breaking changes.
