### PR TITLE
Added missing comma in README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ var options = {
     coerce: false,
     sanitize: true,
     trim: true,
-    arrayNotation: false
+    arrayNotation: false,
     alternateTextNode: false
 };
 ```


### PR DESCRIPTION
Added missing comma at "options object for `toJson`" part.